### PR TITLE
Add additional matrix split to nuspec

### DIFF
--- a/NuGet/cef.redist.nuspec
+++ b/NuGet/cef.redist.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>cef.redist</id>
+    <id>cef.redist.$Platform$$DotConfiguration$</id>
     <version>$version$</version>
     <authors>The Chromium Embedded Framework Authors</authors>
     <owners>The CefSharp Authors</owners>
@@ -15,13 +15,12 @@
     <copyright>Copyright © 2008-2014</copyright>
   </metadata>
   <files>
-    <file src="..\cef_binary_3.y.z_windows32\Release\*.dll" target="CEF\x86" />
-    <file src="..\cef_binary_3.y.z_windows64\Release\*.dll" target="CEF\x64" />
+    <file src="..\cef_binary_3.y.z_$CPlatform$\$Configuration$\*.dll" target="CEF\$Platform$" />
 	
-    <file src="..\cef_binary_3.y.z_windows32\Resources\cef.pak" target="CEF\"/>
-    <file src="..\cef_binary_3.y.z_windows32\Resources\devtools_resources.pak" target="CEF\"/>
-    <file src="..\cef_binary_3.y.z_windows32\Resources\locales\en-US.pak" target="CEF\locales"/>
+    <file src="..\cef_binary_3.y.z_$CPlatform$\Resources\cef.pak" target="CEF\"/>
+    <file src="..\cef_binary_3.y.z_$CPlatform$\Resources\devtools_resources.pak" target="CEF\"/>
+    <file src="..\cef_binary_3.y.z_$CPlatform$\Resources\locales\en-US.pak" target="CEF\locales"/>
 
-    <file src="cef.redist.targets" target="build" />
+    <file src="cef.redist.targets" target="build\cef.redist.$Platform$$DotConfiguration$.targets" />
   </files>
 </package>

--- a/NuGet/cef.redist.targets
+++ b/NuGet/cef.redist.targets
@@ -1,19 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="CefRedistCopyDllPak" BeforeTargets="AfterBuild">
+  <!-- Only execute if the Platform folder exists in this package -->
+  <Target Name="CefRedistCopyDllPak" BeforeTargets="AfterBuild" Condition="Exists('$(MSBuildThisFileDirectory)..\CEF\$(Platform)')">
     <ItemGroup>
       <CefBinaries Include="$(MSBuildThisFileDirectory)..\CEF\$(Platform)\*.*" />
       <CefPakFiles Include="$(MSBuildThisFileDirectory)..\CEF\*.*" />
       <CefLocales Include="$(MSBuildThisFileDirectory)..\CEF\locales\*.*" />
     </ItemGroup>
     <Message Importance="high" Text="-- cef.redist.targets at $(MSBuildThisFileDirectory)" />
-
     <Message Importance="high" Text="Copying CEF .dll files from $(MSBuildThisFileDirectory)..\CEF\$(Platform) to $(TargetDir)" />
     <Copy SourceFiles="@(CefBinaries)" DestinationFolder="$(TargetDir)" />
-
     <Message Importance="high" Text="Copying CEF .pak files from $(MSBuildThisFileDirectory)..\CEF to $(TargetDir)" />
     <Copy SourceFiles="@(CefPakFiles)" DestinationFolder="$(TargetDir)" />
-
     <Message Importance="high" Text="Copying CEF locales    from $(MSBuildThisFileDirectory)..\CEF\locales to $(TargetDir)\locales" />
     <Copy SourceFiles="@(CefLocales)" DestinationFolder="$(TargetDir)\locales" />
   </Target>

--- a/NuGet/cef.sdk.props
+++ b/NuGet/cef.sdk.props
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <Reference Condition="'$(Platform)' == 'x86'"
-             Include="$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.dll" />
-
-    <Reference Condition="'$(Platform)' == 'x64'"
-               Include="$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.dll" />
-  </ItemGroup>
   <PropertyGroup>
-    <CefSdkVer>cef.sdk.3.1750.1738-pre1</CefSdkVer>
+    <CefSdkVer>cef.sdk.3.1750.1738-pre2</CefSdkVer>
   </PropertyGroup>
-
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -3,7 +3,7 @@ param(
     [Parameter(Position = 0)] 
     [string] $Target = "nupkg",
     [Parameter(Position = 1)]
-    [string] $Version = "3.1750.1738-pre1"
+    [string] $Version = "3.1750.1738-pre2"
 )
 
 Import-Module BitsTransfer
@@ -362,8 +362,25 @@ function Nupkg
     $Text = (Get-Content $Filename) -replace '<CefSdkVer>.*<\/CefSdkVer>', "<CefSdkVer>cef.sdk.$Version</CefSdkVer>"
     [System.IO.File]::WriteAllLines($Filename, $Text)
 
-    # Build packages
-    . $nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $Version -OutputDirectory nuget
+    $RedistTargetsFilename = Resolve-Path ".\nuget\cef.redist.targets"
+	
+    [xml]$xml = Get-Content $RedistTargetsFilename
+    $xml.Project.Target | Foreach-Object { $_.Name = 'CefRedistCopyDllPak32'}
+    $xml.Save($RedistTargetsFilename)
+	
+    # Build 32bit packages
+    . $nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $Version -Properties 'Configuration=Debug;DotConfiguration=.Debug;Platform=x86;CPlatform=windows32;' -OutputDirectory nuget
+    . $nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $Version -Properties 'Configuration=Release;DotConfiguration=.Release;Platform=x86;CPlatform=windows32;' -OutputDirectory nuget
+	
+    [xml]$xml = Get-Content $RedistTargetsFilename
+    $xml.Project.Target | Foreach-Object { $_.Name = 'CefRedistCopyDllPak64'}
+    $xml.Save($RedistTargetsFilename)
+	
+    # Build 64bit packages
+    . $nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $Version -Properties 'Configuration=Debug;DotConfiguration=.Debug;Platform=x64;CPlatform=windows64;' -OutputDirectory nuget
+    . $nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $Version -Properties 'Configuration=Release;DotConfiguration=.Release;Platform=x64;CPlatform=windows64;' -OutputDirectory nuget
+	
+    # Build sdk package
     . $nuget pack nuget\cef.sdk.nuspec -NoPackageAnalysis -Version $Version -OutputDirectory nuget
 }
 


### PR DESCRIPTION
Update targets file to only import if matching $Platform
When building cef.redist nuget packages update cef.redist.targets to include a unique target name for 32/64bit otherwise they don't seem to coexist happily
Remove item group entries, don't believe it's relevant anymore
