### PR TITLE
Fix Platform in targets file

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -385,7 +385,9 @@ function Nupkg
     $RedistTargetsFilename = Resolve-Path ".\nuget\cef.redist.targets"
 
     # Write 32bit redist target
-    [xml]$Xml = Get-Content $RedistTargetsFilename
+    [string]$xmlString = Get-Content $RedistTargetsFilename
+    $xmlString = $xmlString.Replace("`$(Platform)", "x86")
+    [xml]$Xml = $xmlString
     $Xml.Project.Target | Foreach-Object { $_.Name = 'CefRedistCopyDllPak32'}
     $Xml.Save($RedistTargetsFilename)
 	
@@ -394,9 +396,12 @@ function Nupkg
     . $Nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $CefPackageVersion -Properties 'Configuration=Release;DotConfiguration=;Platform=x86;CPlatform=windows32;' -OutputDirectory nuget
 	
     # Write 64bit redist target
-    [xml]$Xml = Get-Content $RedistTargetsFilename
-    $Xml.Project.Target | Foreach-Object { $_.Name = 'CefRedistCopyDllPak64'}
+    [string]$xmlString = Get-Content $RedistTargetsFilename
+    $xmlString = $xmlString.Replace("x86", "x64")
+    [xml]$Xml = $xmlString
+    $Xml.Project.Target | Foreach-Object { $_.Name = 'CefRedistCopyDllPak64'}        
     $Xml.Save($RedistTargetsFilename)
+
 	
     # Build 64bit packages
     #. $Nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $CefPackageVersion -Properties 'Configuration=Debug;DotConfiguration=.Debug;Platform=x64;CPlatform=windows64;' -OutputDirectory nuget

--- a/build.ps1
+++ b/build.ps1
@@ -387,23 +387,13 @@ function Nupkg
     $TemplateTargetsFilename = ".\nuget\cef.redist.template.targets"
     Copy-Item $RedistTargetsFilename $TemplateTargetsFilename
 
-    # Write 32bit redist target
-    [string]$xmlString = Get-Content $TemplateTargetsFilename
-    $xmlString = $xmlString.Replace("`$(Platform)", "x86")
-    [xml]$Xml = $xmlString
-    $Xml.Project.Target | Foreach-Object { $_.Name = 'CefRedistCopyDllPak32'}
-    $Xml.Save($RedistTargetsFilename)
-	
+    Edit-TargetsFile 32
+
     # Build 32bit packages
     #. $Nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $CefPackageVersion -Properties 'Configuration=Debug;DotConfiguration=.Debug;Platform=x86;CPlatform=windows32;' -OutputDirectory nuget
     . $Nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $CefPackageVersion -Properties 'Configuration=Release;DotConfiguration=;Platform=x86;CPlatform=windows32;' -OutputDirectory nuget
 	
-    # Write 64bit redist target
-    [string]$xmlString = Get-Content $TemplateTargetsFilename
-    $xmlString = $xmlString.Replace("`$(Platform)", "x64")
-    [xml]$Xml = $xmlString
-    $Xml.Project.Target | Foreach-Object { $_.Name = 'CefRedistCopyDllPak64'}        
-    $Xml.Save($RedistTargetsFilename)
+    Edit-TargetsFile 64
 	
     # Build 64bit packages
     #. $Nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $CefPackageVersion -Properties 'Configuration=Debug;DotConfiguration=.Debug;Platform=x64;CPlatform=windows64;' -OutputDirectory nuget
@@ -417,6 +407,27 @@ function Nupkg
     [System.IO.File]::WriteAllLines($Filename, $Text)
 
     . $Nuget pack nuget\cef.sdk.nuspec -NoPackageAnalysis -Version $CefPackageVersion -OutputDirectory nuget
+}
+
+function Edit-TargetsFile($platformBitness)
+{
+    if ($platformBitness -eq 32)
+    {
+        $platformDescriptor = "x86"
+    }
+    else
+    {
+        $platformDescriptor = "x64"
+    }
+
+    # Set the appropriate platform directory for the bitness of CEF
+    [string]$xmlString = Get-Content $TemplateTargetsFilename
+    $xmlString = $xmlString.Replace("`$(Platform)", $platformDescriptor)
+
+    # Set the Target name to include the bitness of CEF
+    [xml]$Xml = $xmlString
+    $Xml.Project.Target | Foreach-Object { $_.Name = "CefRedistCopyDllPak${platformBitness}"}
+    $Xml.Save($RedistTargetsFilename)
 }
 
 function DownloadNuget()

--- a/build.ps1
+++ b/build.ps1
@@ -383,6 +383,7 @@ function Nupkg
 
     # Redist target
     $RedistTargetsFilename = Resolve-Path ".\nuget\cef.redist.targets"
+    [xml]$originalTargetsContents = Get-Content $RedistTargetsFilename
 
     $TemplateTargetsFilename = ".\nuget\cef.redist.template.targets"
     Copy-Item $RedistTargetsFilename $TemplateTargetsFilename
@@ -400,7 +401,8 @@ function Nupkg
     . $Nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $CefPackageVersion -Properties 'Configuration=Release;DotConfiguration=;Platform=x64;CPlatform=windows64;' -OutputDirectory nuget
 
     Remove-Item $TemplateTargetsFilename
-	
+    $originalTargetsContents.Save($RedistTargetsFilename)
+
     # Build sdk
     $Filename = Resolve-Path ".\nuget\cef.sdk.props"
     $Text = (Get-Content $Filename) -replace '<CefSdkVer>.*<\/CefSdkVer>', "<CefSdkVer>cef.sdk.$CefPackageVersion</CefSdkVer>"

--- a/build.ps1
+++ b/build.ps1
@@ -384,8 +384,11 @@ function Nupkg
     # Redist target
     $RedistTargetsFilename = Resolve-Path ".\nuget\cef.redist.targets"
 
+    $TemplateTargetsFilename = ".\nuget\cef.redist.template.targets"
+    Copy-Item $RedistTargetsFilename $TemplateTargetsFilename
+
     # Write 32bit redist target
-    [string]$xmlString = Get-Content $RedistTargetsFilename
+    [string]$xmlString = Get-Content $TemplateTargetsFilename
     $xmlString = $xmlString.Replace("`$(Platform)", "x86")
     [xml]$Xml = $xmlString
     $Xml.Project.Target | Foreach-Object { $_.Name = 'CefRedistCopyDllPak32'}
@@ -396,16 +399,17 @@ function Nupkg
     . $Nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $CefPackageVersion -Properties 'Configuration=Release;DotConfiguration=;Platform=x86;CPlatform=windows32;' -OutputDirectory nuget
 	
     # Write 64bit redist target
-    [string]$xmlString = Get-Content $RedistTargetsFilename
-    $xmlString = $xmlString.Replace("x86", "x64")
+    [string]$xmlString = Get-Content $TemplateTargetsFilename
+    $xmlString = $xmlString.Replace("`$(Platform)", "x64")
     [xml]$Xml = $xmlString
     $Xml.Project.Target | Foreach-Object { $_.Name = 'CefRedistCopyDllPak64'}        
     $Xml.Save($RedistTargetsFilename)
-
 	
     # Build 64bit packages
     #. $Nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $CefPackageVersion -Properties 'Configuration=Debug;DotConfiguration=.Debug;Platform=x64;CPlatform=windows64;' -OutputDirectory nuget
     . $Nuget pack nuget\cef.redist.nuspec -NoPackageAnalysis -Version $CefPackageVersion -Properties 'Configuration=Release;DotConfiguration=;Platform=x64;CPlatform=windows64;' -OutputDirectory nuget
+
+    Remove-Item $TemplateTargetsFilename
 	
     # Build sdk
     $Filename = Resolve-Path ".\nuget\cef.sdk.props"


### PR DESCRIPTION
If you add cef.redist to a project that is configured for `AnyCPU`, the post-build copy operations do not function. This is because the cef.redist.targets file specifies that MSBuild looks in a directory named after the value of `$(Platform)`, but the only values of `$(Platform)` that are valid in this context are x86 and x64. The location is dependent on the package version pulled in, not the bitness of the project to which the package was added.

This pull request updates build.ps1 to replace instances of `$(Platform)` with the appropriate location for the package bitness before the NuGet package is constructed. 