### PR TITLE
[DO NOT MERGE] Temporary hack to build using custom CEF build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,10 @@
 environment:
+  # I.e. Visual Studio 2013. This affects which VC++ redistributable version is required for using the generated DLLs.
   VisualStudioVersion: 12.0
 
 version: 62.0.0-CI{build}
 
 shallow_clone: true
-
-# Start builds on tags only (GitHub and BitBucket)
-skip_non_tags: true
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:


### PR DESCRIPTION
The idea here is to let me build highly experimental CEF NuGet packages, which provides the proprietary codecs.

I spent the weekend (yes, literally; it took many hours to set up the build environment and wait for 30000 files to compile...) building a custom version of CEF with proprietary codecs enabled, for those willing to take the legal risk of using them.

The packages are here now:

https://www.myget.org/feed/perlun/package/nuget/cef.sdk
https://www.myget.org/feed/perlun/package/nuget/cef.redist.x86

(x86 only for now, since linking failed with an out-of-memory error after about an hour or so waiting to link `libcef.dll` in the x64 target.)

This serves as an intermediate solution while we wait for CEF ~63~ 64 (unfortunately), which will include (some) of the proprietary codecs which are now considered "safe" to use from a legal/patent perspective. More details: https://github.com/cefsharp/CefSharp/issues/1479
