### PR TITLE
Fallback to using system cmake if chocolatey cmake not found

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -324,8 +324,12 @@ try
 			rm CMakeCache.txt -ErrorAction:SilentlyContinue
 			rm -r CMakeFiles -ErrorAction:SilentlyContinue
 			Write-Diagnostic "Running cmake"
-			&"$($env:ChocolateyInstall)\bin\cmake.exe" --version
-			&"$($env:ChocolateyInstall)\bin\cmake.exe" -LAH -G "$CmakeGenerator$CmakeArch" -DUSE_SANDBOX=Off -DCEF_RUNTIME_LIBRARY_FLAG=/MD .
+			$cmake_path = "cmake.exe";
+			if ($env:ChocolateyInstall -And (Test-Path ($env:ChocolateyInstall + "\" + $cmake_path) )){
+				$cmake_path = $env:ChocolateyInstall + "\" + $cmake_path;
+			}
+			&"$cmake_path" -LAH -G "$CmakeGenerator$CmakeArch" -DUSE_SANDBOX=Off -DCEF_RUNTIME_LIBRARY_FLAG=/MD .
+			
 			popd
 			$env:CEFSHARP_BUILD_IS_BOOTSTRAPPED = "$Toolchain$Platform"
 		}


### PR DESCRIPTION
I don't think this code was meant to stick around.  If so maybe we should only use it if cmake cannot be found?  That or we should provide some override for it.    