### PR TITLE
Builds with custom suffix

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -20,6 +20,8 @@ param(
 	[Parameter()]
 	[string] $Extension = "tar.bz2",
 	[Switch] $NoDebugBuild
+	[string] $Suffix
+	
 )
 
 Set-StrictMode -version latest
@@ -83,6 +85,11 @@ try
 		# Take the cef version and strip the commit hash, chromium version 
 		# we should end up with something like 73.1.12
 		$CefPackageVersion = $CefVersion.SubString(0, $CefVersion.IndexOf('+'))
+	}
+	
+	if($Suffix)
+	{
+		$CefPackageVersion = $CefPackageVersion + '-' + $Suffix
 	}
 
 	# https://github.com/jbake/Powershell_scripts/blob/master/Invoke-BatchFile.ps1


### PR DESCRIPTION
Allows to build package with customised version of CEF

Often I need to build customised version of CEF and package suffix really helps in this case. So, for forced video hardware decode I just run command like this:

```sh
powershell -File build.ps1 nupkg-only local ".." 3.%CHROMIUM_TAG%.%NUGET_BUILD%.g%CHROMIUM_SHA% -Extension zip -Suffix hwenc
```