### PR TITLE
Fixed detection of VS2017InstallPath when both, Visual Studio 2017 an…

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -293,7 +293,7 @@ try
 			
 				Write-Diagnostic "VSWhere path $vswherePath"
 			
-				$VS2017InstallPath = & $vswherePath -version 15 -property installationPath
+				$VS2017InstallPath = & $vswherePath -version '[15.0,16.0)' -property installationPath
 			
 				Write-Diagnostic "VS2017InstallPath: $VS2017InstallPath"
 				


### PR DESCRIPTION
When Visual Studio 2017 and 2019 are installed, the command 
`$VS2017InstallPath = & $vswherePath -version 15 -property installationPath`
returns a list of installed Visual Studio installation paths. The filter '[15.0,16.0)' ensures that only Visual Studio 2017 path is returned. Otherwise the build script failes: 

Msvs : Cannot process argument transformation on parameter 'Path'. Cannot convert value to type System.String.