### PR TITLE
Add -BuildArches to specify what platforms to build for (ie "x86 arm64")

### DIFF
--- a/NuGet/chromiumembeddedframework.runtime.nuspec.template
+++ b/NuGet/chromiumembeddedframework.runtime.nuspec.template
@@ -25,13 +25,7 @@
 	<!-- Architecture-specific files folder hierarchy lost (native subfolders)  -->
     <!-- https://github.com/NuGet/Home/issues/7698#issuecomment-455368655 -->
     <!-- We have to copy swiftshader and locales via manually -->
-    <file src="..\cef_binary_3.y.z_windows32\Resources\locales\*.pak" target="CEF\win-x86\locales"/>
-    <file src="..\cef_binary_3.y.z_windows32\$Configuration$\swiftshader\*.dll" target="CEF\win-x86\swiftshader" />
-	<file src="..\cef_binary_3.y.z_windows64\Resources\locales\*.pak" target="CEF\win-x64\locales"/>
-    <file src="..\cef_binary_3.y.z_windows64\$Configuration$\swiftshader\*.dll" target="CEF\win-x64\swiftshader" />
-    <file src="..\cef_binary_3.y.z_windowsarm64\Resources\locales\*.pak" target="CEF\win-arm64\locales"/>
-    <file src="..\cef_binary_3.y.z_windowsarm64\$Configuration$\swiftshader\*.dll" target="CEF\win-arm64\swiftshader" />
-    <file src="..\cef_binary_3.y.z_windows32\LICENSE.txt" target="LICENSE.txt" />
+    META_REPLACE_DATA
     <file src="chromiumembeddedframework.runtime.json" target="runtime.json" />
 	<file src="chromiumembeddedframework.runtime.props" target="buildTransitive\" />
     <file src="cef128x128.png" target="images\" />

--- a/NuGet/chromiumembeddedframework.runtime.win.nuspec
+++ b/NuGet/chromiumembeddedframework.runtime.win.nuspec
@@ -29,7 +29,7 @@
     <file src="..\cef_binary_3.y.z_$CPlatform$\Resources\*.dat" target="runtimes\win-$Platform$\native\"/>
     <file src="..\cef_binary_3.y.z_$CPlatform$\Readme.txt" target="\"/>
     
-    <file src="..\cef_binary_3.y.z_windows32\LICENSE.txt" target="LICENSE.txt" />
+    <file src="..\cef_binary_3.y.z_$CPlatform$\LICENSE.txt" target="LICENSE.txt" />
     <file src="cef128x128.png" target="images\" />
   </files>
 </package>


### PR DESCRIPTION
Removed much of the platform specific code redundancy
Fixes #98.   

Most is pretty straightforward but a few specific notes:

-- Added -Wno-dev to cmake calls, this suppresses some warnings that were dumping to screen but not causing an issue for the build.  The flag is only for author of the CMakeLists.txt per https://cmake.org/cmake/help/latest/manual/cmake.1.html#manual:cmake(1) I believe we are using the generator to do this and not ourselves.

-- In the current build.ps1 there is a step that `# Make sure there is a 32bit and 64bit version for the specified build` and that they are the same version.  It still does this check but it does it as it goes so will start downloading versions and only stop once it detects there is a mismatch.   Done this way to just save an extra loop and because I couldn't think of any harm coming of it.

-- The way I am building the nuspec for the runtime is a bit sloppy with hardcoded strings in the build.ps1 script.   Using an actual templating engine would be better, but as this is powershell it seemed easiest to do this small replacement in this fashion.