### PR TITLE
Fix vs2022 target

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -236,10 +236,10 @@ function Msvs
 	$VS_VER = 16;
 	$VS_OFFICIAL_VER = 2019;
 		
-	if ($_ -eq 'v143')
+	if ($Toolchain -eq 'v143')
 	{
 		$VS_VER=17;
-		$VS_OFFICIAL_VER=2021;
+		$VS_OFFICIAL_VER=2022;
 	}
 	
 	Write-Diagnostic "VSWhere path $global:VSwherePath"


### PR DESCRIPTION

This PR fixes #103 (detect vs2022).

It also adds support for using VS Build Tools instead of VS IDE versions. Build Tools are slimmer than the IDE and are well suited for docker build images. Build tools 2019 and 2022 should both work.

Tested only with Visual Studio Build Tools 2022.