### PR TITLE
Add support for Visual Studio Build Tools

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -251,7 +251,13 @@ function Msvs
 		
 	if($null -eq $VSInstallPath -or !(Test-Path $VSInstallPath))
 	{
-		Die "Visual Studio $VS_OFFICIAL_VER was not found"
+		$VSInstallPath = & $global:VSwherePath -version $versionSearchStr -property installationPath -products 'Microsoft.VisualStudio.Product.BuildTools'
+		Write-Diagnostic "BuildTools $($VS_OFFICIAL_VER)InstallPath: $VSInstallPath"
+
+		if($null -eq $VSInstallPath -or !(Test-Path $VSInstallPath))
+		{
+			Die "Visual Studio $VS_OFFICIAL_VER was not found"
+		}
 	}
 		
 	$VisualStudioVersion = "$VS_VER.0"


### PR DESCRIPTION
Adds support for using VS Build Tools instead of VS IDE versions. Build Tools are slimmer than the IDE and are well suited for docker build images. Build tools 2019 and 2022 should both work.

Tested only with Visual Studio Build Tools 2022.